### PR TITLE
Initial-config

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,10 +12,12 @@ services:
     command: "dagster-daemon run"
   dagster-postgres:
     image: postgres:17
+    env_file:
+      - .env
     ports:
       - 5432:5432
     environment:
-      - POSTGRES_PASSWORD=secret
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - dagster-postgres:/var/lib/postgresql/data
 volumes:

--- a/workspace.yaml_example
+++ b/workspace.yaml_example
@@ -1,0 +1,6 @@
+load_from:
+  - python_module: dagster_example
+  - grpc_server:
+      host: custom-pipeline
+      port: 3001
+      location_name: "CUSTOM-PIPELINE"


### PR DESCRIPTION
Alter workspace config to connect to an unrelated repositories pipeline running in an independant docker container. Must have network connectivity, such as shared network in docker-compose.